### PR TITLE
[feat](test): support ctest enable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,15 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+option(ENABLE_TESTING "Enable unit test build" ON)
+
 include_directories(include)
 add_subdirectory(src)
-add_subdirectory(test)
+
+if(ENABLE_TESTING)
+    enable_testing()
+    add_subdirectory(test)
+endif()
 
 add_executable(sc main.cpp)
 target_link_libraries(sc sc_front_lib_shared)

--- a/test/IR/CMakeLists.txt
+++ b/test/IR/CMakeLists.txt
@@ -1,11 +1,20 @@
-file(GLOB sc_ir_test_src
-    "*.cpp")
+file(GLOB sc_ir_test_src "*.cpp")
 
 add_executable(sc_ir_test ${sc_ir_test_src})
 add_dependencies(sc_ir_test gtest)
-target_link_libraries(sc_ir_test PUBLIC sc_ir_lib_static)
-target_link_libraries(sc_ir_test PUBLIC ${GTEST_MAIN_STATIC_LIB})
-target_link_libraries(sc_ir_test PUBLIC ${GTEST_STATIC_LIB})
-target_link_libraries(sc_ir_test PUBLIC ${GMOCK_STATIC_LIB})
-target_include_directories(sc_ir_test PUBLIC ${GTEST_INCLUDE_DIR})
-target_include_directories(sc_ir_test PUBLIC ${CMAKE_SOURCE_DIR}/test/IR)
+
+target_link_libraries(sc_ir_test PUBLIC
+    sc_ir_lib_static
+    ${GTEST_MAIN_STATIC_LIB}
+    ${GTEST_STATIC_LIB}
+    ${GMOCK_STATIC_LIB}
+)
+
+target_include_directories(sc_ir_test PUBLIC
+    ${GTEST_INCLUDE_DIR}
+    ${CMAKE_SOURCE_DIR}/test/IR
+)
+
+# Add test configuration
+enable_testing()
+add_test(NAME sc_ir_test COMMAND sc_ir_test)

--- a/test/front/CMakeLists.txt
+++ b/test/front/CMakeLists.txt
@@ -1,10 +1,17 @@
-file(GLOB sc_front_test_src
-    "*.cpp")
+file(GLOB sc_front_test_src "*.cpp")
 
 add_executable(sc_front_test ${sc_front_test_src})
 add_dependencies(sc_front_test gtest)
-target_link_libraries(sc_front_test PUBLIC sc_front_lib_static)
-target_link_libraries(sc_front_test PUBLIC ${GTEST_MAIN_STATIC_LIB})
-target_link_libraries(sc_front_test PUBLIC ${GTEST_STATIC_LIB})
-target_link_libraries(sc_front_test PUBLIC ${GMOCK_STATIC_LIB})
+
+target_link_libraries(sc_front_test PUBLIC 
+    sc_front_lib_static
+    ${GTEST_MAIN_STATIC_LIB}
+    ${GTEST_STATIC_LIB}
+    ${GMOCK_STATIC_LIB}
+)
+
 target_include_directories(sc_front_test PUBLIC ${GTEST_INCLUDE_DIR})
+
+# Add test configuration
+enable_testing()
+add_test(NAME sc_front_test COMMAND sc_front_test)

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -1,9 +1,17 @@
-file(GLOB sc_utils_test_src
-    "*.cpp")
+file(GLOB sc_utils_test_src "*.cpp")
 
 add_executable(sc_utils_test ${sc_utils_test_src})
 add_dependencies(sc_utils_test gtest)
-target_link_libraries(sc_utils_test PUBLIC ${GTEST_MAIN_STATIC_LIB})
-target_link_libraries(sc_utils_test PUBLIC ${GTEST_STATIC_LIB})
-target_link_libraries(sc_utils_test PUBLIC ${GMOCK_STATIC_LIB})
+
+# Consolidated target linking
+target_link_libraries(sc_utils_test PUBLIC
+    ${GTEST_MAIN_STATIC_LIB}
+    ${GTEST_STATIC_LIB}
+    ${GMOCK_STATIC_LIB}
+)
+
 target_include_directories(sc_utils_test PUBLIC ${GTEST_INCLUDE_DIR})
+
+# Test configuration
+enable_testing()
+add_test(NAME sc_utils_test COMMAND sc_utils_test)


### PR DESCRIPTION
In fact, originally, you could only compile an executable file and execute it manually; now you can directly use ctest in cmake or use ctest plug-in in vscode to run it with one click.

![image](https://github.com/user-attachments/assets/ef4f5318-7808-44df-9132-4d39b07cd707)
